### PR TITLE
Use a more correct tokenTypes array for Leaf

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,11 +80,7 @@
           "source.css": "css"
         },
         "tokenTypes": {
-          "meta.embedded.tag.leaf.for": "other",
-          "meta.embedded.tag.leaf": "other",
-          "meta.embedded.tag.leaf.simple": "other",
-          "meta.embedded.tag.leaf.nested": "other",
-          "meta.embedded.definition.function.body.leaf": "other"
+          "meta.tag string.quoted": "other"
         },
         "path": "./syntaxes/leaf.tmLanguage.json"
       }


### PR DESCRIPTION
It's not clear that the different set of tokens makes a significant difference, but other languages of this type do this, so it seems prudent.